### PR TITLE
Modifying event verification and plugin compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>be.machigan</groupId>
     <artifactId>LightInteractionForAll</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -11,6 +11,16 @@
     <build>
         <finalName>${project.name}-${project.version}</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <targetPath>.</targetPath>
+                <filtering>true</filtering>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*.yml</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -20,6 +30,18 @@
                     <encoding>UTF-8</encoding>
                     <source>17</source>
                     <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <paperweight-mappings-namespace>mojang</paperweight-mappings-namespace>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/be/machigan/lightinteractionforall/LightInteractionForAll.java
+++ b/src/main/java/be/machigan/lightinteractionforall/LightInteractionForAll.java
@@ -7,6 +7,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Light;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
@@ -20,17 +21,19 @@ public class LightInteractionForAll extends JavaPlugin implements Listener {
         this.getServer().getPluginManager().registerEvents(this, this);
     }
 
-    @EventHandler
-    public void onPlayerInteractWithLight(PlayerInteractEvent e) {
-        if (e.getPlayer().isOp()) return;
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerInteractWithLight(PlayerInteractEvent e)
+    {
+        if(!e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) return;
+        if (!e.getMaterial().equals(Material.LIGHT)) return;
         if (e.getPlayer().isSneaking()) return;
-        if (e.isCancelled()) return;
         if (!e.getPlayer().getGameMode().equals(GameMode.CREATIVE)) return;
-        if (!e.getPlayer().hasPermission("light4all.use")) return;
-        if (e.getClickedBlock() == null) return;
+
         Block block = e.getClickedBlock();
         if (!block.getType().equals(Material.LIGHT)) return;
-        if (!e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.LIGHT)) return;
+
+        if (e.getPlayer().isOp() || !e.getPlayer().hasPermission("light4all.use")) return;
+
         BlockPlaceEvent event = new BlockPlaceEvent(
                 block,
                 block.getState(),

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: be.machigan.lightinteractionforall.LightInteractionForAll
 name: LightInteractionForAll
-version: 1.0.0
+version: ${project.version}
 api-version: 1.21
 author: Machigan
 prefix: Light4All


### PR DESCRIPTION
- Fixing the order of checks to avoid heavy checks first
- Using the maven project version in plugin.yml
- Add paper attribute to avoid unnecessary remapping when using paper